### PR TITLE
Track Go and Actions dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
+  - package-ecosystem: "gomod"
     directory: "/"
-    ignore:
-      - dependency-name: "immutable"
-      - dependency-name: "draft-js-md-converter"
-      - dependency-name: "draft-js"
-      - dependency-name: "apollo-server-micro"
     commit-message:
       prefix: "chore"
     open-pull-requests-limit: 10
@@ -15,3 +10,14 @@ updates:
     labels:
       - "dependencies"
       - "automerge"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "chore"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- port the useful Dependabot ecosystem split from #1276
- track Go modules instead of stale npm packages
- add GitHub Actions update coverage

## Verification
- go test ./...
- git diff --check