### PR TITLE
Tighten CodeQL workflow permissions

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -4,20 +4,16 @@ on:
   push:
   pull_request:
   schedule:
-    #        ┌───────────── minute (0 - 59)
-    #        │  ┌───────────── hour (0 - 23)
-    #        │  │ ┌───────────── day of the month (1 - 31)
-    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-    #        │  │ │ │ │
-    #        │  │ │ │ │
-    #        │  │ │ │ │
-    #        *  * * * *
     - cron: "30 1 * * *"
 
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- port the explicit CodeQL permissions from #1276 while keeping Go analysis
- remove the noisy cron explainer block from the workflow

## Verification
- go test ./...
- git diff --check